### PR TITLE
Add additional isolation test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Azure Examples
 
-This repository contains simple examples demonstrating how to test Azure components using xUnit and NSubstitute.
+This repository shows a minimal .NET solution structured with `src` and `tests` folders. The sample `EventReader` class reads events from a service bus using a connection string from Key Vault.
 
 ## Running tests
 
@@ -9,3 +9,10 @@ Execute the tests with the .NET SDK:
 ```bash
 dotnet test AzureExamples.sln
 ```
+
+The `tests` project includes examples of using mocks and fakes to keep the microservice isolated from Azure during testing.
+These tests demonstrate how to:
+
+- pass `CancellationToken` values through to dependencies
+- propagate exceptions thrown by mocked services
+- run integration-style tests with in-memory fakes instead of Azure resources

--- a/tests/AzureExamples.Tests/EventReaderIsolationTests.cs
+++ b/tests/AzureExamples.Tests/EventReaderIsolationTests.cs
@@ -1,0 +1,54 @@
+using AzureExamples;
+using NSubstitute;
+
+namespace AzureExamples.Tests;
+
+public class EventReaderIsolationTests
+{
+    [Fact]
+    public async Task ReadEventsAsync_PassesCancellationTokenToDependencies()
+    {
+        var serviceBus = Substitute.For<IServiceBus>();
+        var keyVault = Substitute.For<IKeyVault>();
+        keyVault.GetSecretAsync("conn", Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult("Endpoint=sb://test/"));
+        serviceBus.ReceiveMessagesAsync("Endpoint=sb://test/", Arg.Any<CancellationToken>())
+                  .Returns(Task.FromResult<IEnumerable<string>>(Array.Empty<string>()));
+
+        var reader = new EventReader(serviceBus, keyVault, "conn");
+        using var cts = new CancellationTokenSource();
+
+        await reader.ReadEventsAsync(cts.Token);
+
+        await keyVault.Received(1).GetSecretAsync("conn", cts.Token);
+        await serviceBus.Received(1).ReceiveMessagesAsync("Endpoint=sb://test/", cts.Token);
+    }
+
+    [Fact]
+    public async Task ReadEventsAsync_ServiceBusThrows_PropagatesException()
+    {
+        var serviceBus = Substitute.For<IServiceBus>();
+        var keyVault = Substitute.For<IKeyVault>();
+        keyVault.GetSecretAsync("conn", Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult("Endpoint=sb://test/"));
+        serviceBus.ReceiveMessagesAsync("Endpoint=sb://test/", Arg.Any<CancellationToken>())
+                  .Returns(Task.FromException<IEnumerable<string>>(new InvalidOperationException("boom")));
+
+        var reader = new EventReader(serviceBus, keyVault, "conn");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => reader.ReadEventsAsync());
+    }
+
+    [Fact]
+    public async Task ReadEventsAsync_KeyVaultThrows_PropagatesException()
+    {
+        var serviceBus = Substitute.For<IServiceBus>();
+        var keyVault = Substitute.For<IKeyVault>();
+        keyVault.GetSecretAsync("conn", Arg.Any<CancellationToken>())
+                .Returns(Task.FromException<string>(new InvalidOperationException("boom")));
+
+        var reader = new EventReader(serviceBus, keyVault, "conn");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => reader.ReadEventsAsync());
+    }
+}


### PR DESCRIPTION
## Summary
- expand isolation tests to show KeyVault exception handling
- document test scenarios in README

## Testing
- `dotnet test AzureExamples.sln`

------
https://chatgpt.com/codex/tasks/task_e_684593d3b8f0832bab1644896d859d79